### PR TITLE
Add 500ms unread grace window and regression tests

### DIFF
--- a/app/lib/instances/sidebar.test.ts
+++ b/app/lib/instances/sidebar.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { SESSION_UNREAD_GRACE_MS, isSessionUnread } from "~/lib/instances/sidebar";
+
+describe("isSessionUnread", () => {
+  const session = {
+    id: "session-1",
+    title: null,
+    directory: null,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+  };
+
+  it("keeps a session read when activity is within the grace period", () => {
+    expect(isSessionUnread(session, 1_000 - SESSION_UNREAD_GRACE_MS)).toBe(false);
+    expect(isSessionUnread(session, 1_000 - SESSION_UNREAD_GRACE_MS + 1)).toBe(false);
+  });
+
+  it("marks a session unread when activity is outside the grace period", () => {
+    expect(isSessionUnread(session, 1_000 - SESSION_UNREAD_GRACE_MS - 1)).toBe(true);
+  });
+
+  it("marks sessions unread when no read timestamp exists", () => {
+    expect(isSessionUnread(session, null)).toBe(true);
+  });
+});

--- a/app/lib/instances/sidebar.ts
+++ b/app/lib/instances/sidebar.ts
@@ -3,6 +3,7 @@ import type { OpencodeSessionInfo } from "~/lib/opencode/events";
 
 export const SIDEBAR_SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const SIDEBAR_SESSION_LIMIT = 3;
+export const SESSION_UNREAD_GRACE_MS = 500;
 
 export type SidebarSessionRecord = OpencodeSessionSummary & {
   lastReadAt: number | null;
@@ -37,7 +38,7 @@ export function isSessionUnread(session: OpencodeSessionSummary, lastReadAt: num
     return true;
   }
 
-  return sortTime > lastReadAt;
+  return sortTime - lastReadAt > SESSION_UNREAD_GRACE_MS;
 }
 
 export function withSessionReadState(session: OpencodeSessionSummary, lastReadAt: number | null): SidebarSessionRecord {

--- a/app/store/sessions-provider.test.tsx
+++ b/app/store/sessions-provider.test.tsx
@@ -103,13 +103,13 @@ describe("SessionsProvider", () => {
         properties: {
           info: {
             sessionID: "session-1",
-            time: { created: 5 },
+            time: { created: 503 },
           },
         },
       });
     });
 
-    expect(screen.getByTestId("activity")).toHaveTextContent("5");
+    expect(screen.getByTestId("activity")).toHaveTextContent("503");
     expect(screen.getByTestId("read")).toHaveTextContent("2");
     expect(screen.getByTestId("unread")).toHaveTextContent("true");
     expect(screen.getByTestId("title")).toHaveTextContent("Session");
@@ -123,7 +123,7 @@ describe("SessionsProvider", () => {
       });
     });
 
-    expect(screen.getByTestId("activity")).toHaveTextContent("5");
+    expect(screen.getByTestId("activity")).toHaveTextContent("503");
     expect(screen.getByTestId("read")).toHaveTextContent("6");
     expect(screen.getByTestId("unread")).toHaveTextContent("false");
     expect(screen.getByTestId("title")).toHaveTextContent("Session");
@@ -222,5 +222,63 @@ describe("SessionsProvider", () => {
 
     expect(screen.getByTestId("read")).toHaveTextContent("7");
     expect(screen.getByTestId("unread")).toHaveTextContent("false");
+  });
+
+  it("keeps the session read for near-simultaneous optimistic read and activity", () => {
+    let onInstanceEvent: ((event: any) => void) | null = null;
+
+    useInstanceEventsMock.mockImplementation((handler: (event: any) => void) => {
+      onInstanceEvent = handler;
+    });
+    useReadStatusEventsMock.mockImplementation(() => {});
+
+    render(
+      <SessionsProvider initialSessions={initialSessions}>
+        <TestConsumer />
+        <TestMarkReadConsumer />
+      </SessionsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
+
+    if (!onInstanceEvent) {
+      throw new Error("Missing instance event handler");
+    }
+
+    const instanceEventHandler: (event: any) => void = onInstanceEvent;
+
+    act(() => {
+      instanceEventHandler({
+        type: "message.updated",
+        instanceId: "instance-1",
+        properties: {
+          info: {
+            sessionID: "session-1",
+            time: { created: 7 + 500 },
+          },
+        },
+      });
+    });
+
+    expect(screen.getByTestId("activity")).toHaveTextContent("507");
+    expect(screen.getByTestId("read")).toHaveTextContent("7");
+    expect(screen.getByTestId("unread")).toHaveTextContent("false");
+
+    act(() => {
+      instanceEventHandler({
+        type: "message.updated",
+        instanceId: "instance-1",
+        properties: {
+          info: {
+            sessionID: "session-1",
+            time: { created: 7 + 501 },
+          },
+        },
+      });
+    });
+
+    expect(screen.getByTestId("activity")).toHaveTextContent("508");
+    expect(screen.getByTestId("read")).toHaveTextContent("7");
+    expect(screen.getByTestId("unread")).toHaveTextContent("true");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent sessions from flickering unread due to near-simultaneous activity and optimistic read acknowledgements by introducing a small tolerance window for unread calculation.

### Description
- Add a shared `SESSION_UNREAD_GRACE_MS = 500` constant to `app/lib/instances/sidebar.ts` and change `isSessionUnread` to return `sortTime - lastReadAt > SESSION_UNREAD_GRACE_MS`.
- Add unit tests for the grace-window behavior in `app/lib/instances/sidebar.test.ts` covering within-grace, outside-grace, and null `lastReadAt` cases.
- Extend `app/store/sessions-provider.test.tsx` to adjust timing expectations and add a regression that verifies optimistic read + near-simultaneous activity remains read at `+500ms` and becomes unread at `+501ms`.

### Testing
- Ran `npm test -- app/lib/instances/sidebar.test.ts app/store/sessions-provider.test.tsx` and verified both test files passed.
- Test run summary: 2 test files, 8 tests total, all 8 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc68c362608331b57ff01a7dd0d769)